### PR TITLE
docs: fix README content issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.tasks/actions/workflows/ci.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.tasks/actions/workflows/ci.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-hubspot.crm.engagements.tasks.svg)](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.tasks/commits/master)
-[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.engagements.tasks.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%hubspot.crm.engagements.tasks)
+[![GitHub Issues](https://img.shields.io/github/issues/ballerina-platform/ballerina-library/module/hubspot.crm.engagements.tasks.svg?label=Open%20Issues)](https://github.com/ballerina-platform/ballerina-library/labels/module%2Fhubspot.crm.engagements.tasks)
 
 ## Overview
 
 [HubSpot](https://www.hubspot.com/) is an AI-powered customer relationship management (CRM) platform.
 
-The `ballerinax/module-ballerinax-hubspot.crm.engagements.tasks` connector offers APIs to connect and interact with the [Hubspot Engagements Tasks API](https://developers.hubspot.com/docs/guides/api/crm/engagements/tasks) endpoints, specifically based on the HubSpot REST API.
+The `ballerinax/module-ballerinax-hubspot.crm.engagements.tasks` connector offers APIs to connect and interact with the [HubSpot Engagements Tasks API](https://developers.hubspot.com/docs/guides/api/crm/engagements/tasks) endpoints, specifically based on the HubSpot REST API.
 
 ## Setup guide
 
@@ -194,8 +194,6 @@ The `HubSpot CRM Tasks` connector provides practical examples illustrating usage
 1. [Task management in HubSpot CRM](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.tasks/tree/main/examples/assign-or-extend-a-task) - This example searches for a task in HubSpot CRM by its subject, creating a new one if none exists or updating details like the due date and priority if found.
 
 2. [Task completion and status change in HubSpot CRM](https://github.com/ballerina-platform/module-ballerinax-hubspot.crm.engagements.tasks/tree/main/examples/mark-a-task-as-completed) - This example checks a task's status in HubSpot CRM and updates it to "Completed" if necessary, ensuring efficient task management.
-
-[//]: # (TODO: Add examples)
 
 ## Build from the source
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -2,7 +2,7 @@
 
 [HubSpot](https://www.hubspot.com/) is an AI-powered customer relationship management (CRM) platform.
 
-The HubSpot connector offers APIs to connect and interact with the [Hubspot Engagements Tasks API](https://developers.hubspot.com/docs/guides/api/crm/engagements/tasks) endpoints, specifically based on the HubSpot REST API.
+The HubSpot connector offers APIs to connect and interact with the [HubSpot Engagements Tasks API](https://developers.hubspot.com/docs/guides/api/crm/engagements/tasks) endpoints, specifically based on the HubSpot REST API.
 
 ### Key Features
 


### PR DESCRIPTION
## Purpose

Fix documentation issues identified in the HubSpot connector revamp audit.

### README (top-level and `ballerina/README.md`)

- Replace `Hubspot` with `HubSpot` in the brand-name occurrence inside the link text for the Engagements Tasks API reference. Image alt-text and identifier-style occurrences are left as-is.
- Fix the encoding bug in the GitHub Issues badge URL: `module%hubspot.crm.engagements.tasks` -> `module%2Fhubspot.crm.engagements.tasks`.
- Remove the stale `[//]: # (TODO: Add examples)` placeholder from the top-level `README.md`. The Examples section already lists two concrete examples (`assign-or-extend-a-task` and `mark-a-task-as-completed`), so the TODO is misleading.

The `ave` typo and the duplicated-`Ballerina` title issues did not appear in this repo, so no fix was needed for those.

## Examples

N/A - documentation-only change.

## Checklist
- [x] Linked to an issue (Refs `ballerina-platform/ballerina-library#8823`)
- [ ] Updated the changelog - N/A (docs-only)
- [ ] Added tests - N/A (docs-only)
- [ ] Updated the spec - N/A (docs-only)
- [x] Checked native-image compatibility - N/A (no code change)

Refs ballerina-platform/ballerina-library#8823